### PR TITLE
Pass Encoder object by pointer to SetArchitecture()

### DIFF
--- a/lib/encode.go
+++ b/lib/encode.go
@@ -46,7 +46,7 @@ func NewEncoder() Encoder {
 }
 
 // SetArchitecture sets the encoder architecture
-func (encoder Encoder) SetArchitecture(arch int) error {
+func (encoder *Encoder) SetArchitecture(arch int) error {
 	switch arch {
 	case 32:
 		encoder.architecture = 32

--- a/lib/instructions.go
+++ b/lib/instructions.go
@@ -93,8 +93,8 @@ var GarbageMnemonics = []string{
 	"ADD {R},{K};{G};SUB {R},{K}",
 	"SUB {R},{K};{G};ADD {R},{K}",
 	"ROR {R},{K};{G};ROL {R},{K}",
-	"ROL {R},{K};{G};ROR {R},{K}",
-	"PUSH EBP;MOV EBP,ESP;{G};MOV ESP,EBP;POP EBP"} // function prologue/apilogue
+	"ROL {R},{K};{G};ROR {R},{K}"}
+	//"PUSH EBP;MOV EBP,ESP;{G};MOV ESP,EBP;POP EBP"} // function prologue/apilogue, doesn't compile if arch == 64
 
 // JMP 2 -> Jumps to next instruction
 


### PR DESCRIPTION
Previously passed by value, preventing the architecture being set
on the original Encoder object. This caused all output to be 32-bit.

Fixing this revealed that the function prologue/epilogue garbage
mnemonic pattern does not compile if architecture is set to 64, so
commented that out.