### PR TITLE
Add new golang install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can get the pre-compiled binaries [HERE](https://github.com/EgeBalci/sgn/rel
 The only dependency for building the source is the [keystone engine](https://github.com/keystone-engine/keystone), follow [these](https://github.com/keystone-engine/keystone/blob/master/docs/COMPILE.md) instructions for installing the library. Once libkeystone is installed on the system, simply just go get it ツ
 
 ```
-go get github.com/EgeBalci/sgn
+go install github.com/EgeBalci/sgn@latest
 ```
 
 ***DOCKER INSTALL***


### PR DESCRIPTION
When trying to install `sgn` via `go get`, there is an error message:

```
~ $ go get github.com/EgeBalci/sgn
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
```

Since `go get` was deprecated, `go install` should be used instead:

```
~ $ go install github.com/EgeBalci/sgn@latest
go: downloading github.com/EgeBalci/sgn v0.0.0-20211030105722-e3b0703a68cc
go: downloading github.com/briandowns/spinner v1.11.1
go: downloading github.com/fatih/color v1.10.0
go: downloading github.com/EgeBalci/keystone-go v0.0.0-20200525180613-e6c7cd32ceae
go: downloading github.com/olekukonko/tablewriter v0.0.4
go: downloading github.com/mattn/go-colorable v0.1.8
go: downloading github.com/mattn/go-isatty v0.0.12
go: downloading golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
go: downloading github.com/mattn/go-runewidth v0.0.7
```